### PR TITLE
Add stage 3 and ammo mechanic

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
   <div id="success" style="display:none; position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); background:rgba(0,0,0,0.7); color:#fff; padding:2rem; font-size:2rem;">You Succeeded!</div>
   <button id="restart">Start Game</button>
   <button id="nextStage" style="display:none; position:absolute; top:60%; left:50%; transform:translate(-50%,-50%); padding:0.5rem 1rem; font-size:1.2rem; cursor:pointer; background:#2196f3; color:white; border:none; border-radius:4px;">Start Stage 2</button>
+  <button id="nextStage3" style="display:none; position:absolute; top:65%; left:50%; transform:translate(-50%,-50%); padding:0.5rem 1rem; font-size:1.2rem; cursor:pointer; background:#ff5722; color:white; border:none; border-radius:4px;">Start Stage 3</button>
   <script>
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas.getContext('2d');
@@ -60,6 +61,7 @@
     const restartBtn = document.getElementById('restart');
     const successEl = document.getElementById('success');
     const nextStageBtn = document.getElementById('nextStage');
+    const nextStage3Btn = document.getElementById('nextStage3');
 
     const GRID = [
       [1,1,1,1,1,1,1,1,1,1],
@@ -76,7 +78,7 @@
     let TILE;
     const INITIAL_SPEED = 3;
     const FOOD_EMOJIS = ['🍎','🍌','🥕','🍇','🍉','🍞','🍪','🍔','🍕','🍗','🍚','🍩','🍿','🍼','🥛','🥤'];
-    let baby, food, mothers, timerId, timeStart, score, gameOver;
+    let baby, food, mothers, timerId, timeStart, score, ammo, gameOver;
     let currentFoodEmoji = '🍎';
     let babyEmoji = '👶';
     const MOTHER_EMOJI = '🤱';
@@ -96,16 +98,19 @@
       baby = { x: TILE + TILE/2, y: TILE + TILE/2, r: 15, vx:0, vy:0, speed: INITIAL_SPEED };
       spawnFood();
       mothers = [];
-      if (currentStage === 2) {
-        spawnMothers();
+      if (currentStage >= 2) {
+        const count = currentStage === 2 ? 3 : 5;
+        spawnMothers(count);
       }
       timeStart = Date.now();
       score = 0;
+      ammo = 0;
       gameOver = false;
       gameOverEl.style.display = 'none';
       restartBtn.style.display = 'none';
       successEl.style.display = 'none';
       nextStageBtn.style.display = 'none';
+      nextStage3Btn.style.display = 'none';
       clearTimeout(timerId);
       timerId = setTimeout(endGame, 13000);
       requestAnimationFrame(loop);
@@ -181,6 +186,10 @@
             baby.vy = 0;
             baby.y = Math.floor(baby.y / TILE) * TILE + TILE/2;
             break;
+          case 'a':
+          case 'A':
+            throwFood();
+            break;
         }
       });
 
@@ -196,12 +205,38 @@
 
     restartBtn.addEventListener('click', startGame);
     nextStageBtn.addEventListener('click', startStage2);
+    nextStage3Btn.addEventListener('click', startStage3);
 
     function startStage2() {
       currentStage = 2;
       successEl.style.display = 'none';
       nextStageBtn.style.display = 'none';
       init();
+    }
+
+    function startStage3() {
+      currentStage = 3;
+      successEl.style.display = 'none';
+      nextStageBtn.style.display = 'none';
+      nextStage3Btn.style.display = 'none';
+      init();
+    }
+
+    function throwFood() {
+      if (ammo <= 0 || mothers.length === 0) return;
+      let closest = -1;
+      let dist = Infinity;
+      for (let i = 0; i < mothers.length; i++) {
+        const md = Math.hypot(baby.x - mothers[i].x, baby.y - mothers[i].y);
+        if (md < dist) {
+          dist = md;
+          closest = i;
+        }
+      }
+      if (dist <= TILE * 2 && closest >= 0) {
+        mothers.splice(closest, 1);
+        ammo -= 1;
+      }
     }
 
     function isWall(x, y) {
@@ -229,10 +264,21 @@
           baby.r += 2;
           baby.speed += 0.5;
           score += 1;
+          if (currentStage === 2 && (currentFoodEmoji === '🍌' || currentFoodEmoji === '🍎')) {
+            ammo += 1;
+          }
           if (score >= 10 && currentStage === 1) {
             gameOver = true;
             successEl.style.display = 'block';
             nextStageBtn.style.display = 'block';
+            babyEmoji = '👶';
+            clearTimeout(timerId);
+            return;
+          }
+          if (score >= 20 && currentStage === 2) {
+            gameOver = true;
+            successEl.style.display = 'block';
+            nextStage3Btn.style.display = 'block';
             babyEmoji = '👶';
             clearTimeout(timerId);
             return;
@@ -244,7 +290,7 @@
           timerId = setTimeout(endGame, 13000);
         }
 
-        if (currentStage === 2) {
+        if (currentStage >= 2) {
           for (const m of mothers) {
             const md = Math.hypot(baby.x - m.x, baby.y - m.y);
             if (md < baby.r + m.r) {
@@ -293,7 +339,7 @@
       ctx.textBaseline = 'middle';
       ctx.fillText(babyEmoji, baby.x, baby.y);
 
-      if (currentStage === 2) {
+      if (currentStage >= 2) {
         for (const m of mothers) {
           ctx.font = `${m.r * 2}px sans-serif`;
           ctx.textAlign = 'center';
@@ -307,11 +353,12 @@
       // HUD
       const timeLeft = Math.max(0, 13 - Math.floor((Date.now() - timeStart) / 1000));
       ctx.fillStyle = 'rgba(255,255,255,0.8)';
-      ctx.fillRect(5,5,120,50);
+      ctx.fillRect(5,5,140,70);
       ctx.fillStyle = '#000';
       ctx.font = 'bold 20px Arial';
       ctx.fillText(`Time: ${timeLeft}s`, 10, 30);
       ctx.fillText(`Score: ${score}`, 10, 50);
+      ctx.fillText(`Ammo: ${ammo}`, 10, 70);
     }
 
     function loop() {


### PR DESCRIPTION
## Summary
- show button to start stage 3
- accumulate banana and apple as ammo during stage 2
- allow throwing ammo at nearby mothers with the 'A' key
- add HUD display for ammo count
- unlock stage 3 after collecting 20 foods

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68505fa071208321be98252eeca14d26