### PR TITLE
Update README for static hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,12 @@ Next.js 15 (App Router) project for the FreeGames4Eva platform. This skeleton se
 
 ## Getting Started
 
+Simply open `index.html` in your browser. For local development you can also
+serve the repository with a small static server:
+
 ```bash
-npm install
-npm run dev
+npx http-server .
 ```
-
-Create a `.env.local` based on `.env.example` before running in production.
-
-### Deployment
-
-The project is optimised for [Vercel](https://vercel.com). Push the repo, connect to Vercel and set environment variables. SSR caches may be configured via the `revalidate` prop in page components.
 
 ### Testing
 
@@ -22,3 +18,11 @@ npm test
 ```
 
 Lighthouse CI runs in GitHub Actions to ensure SEO and PWA scores remain high.
+
+### Assets
+
+Static files live in the `public/` directory. The service worker at
+`public/sw.js` caches navigation requests for offline access. When modifying its
+behaviour or updating asset filenames, update the `CACHE` name inside the file
+so browsers fetch the latest version. Other files such as `public/robots.txt`
+can be edited directly.


### PR DESCRIPTION
## Summary
- clarify how to start the project by opening `index.html` or running a static server
- drop old Vercel deployment notes
- document static assets and how to refresh the service worker cache

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ee88b6008321ae0d7bc998a7f81c