### PR TITLE
Add navigation hub and isometric layout

### DIFF
--- a/baseline.html
+++ b/baseline.html
@@ -4,125 +4,48 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>FreeGames4Eva</title>
+  <link rel="stylesheet" href="style.css">
   <style>
-    body {
-      font-family: Arial, sans-serif;
-      margin: 0;
-      padding: 0;
-      background: linear-gradient(-45deg, #ffe29f, #ffa99f, #a7cdf0, #ffe29f);
-      background-size: 400% 400%;
-      animation: gradientShift 15s ease infinite;
-    }
-    header { background: #333; color: white; padding: 1rem; text-align: center; }
-    .hero { padding: 2rem; text-align: center; background: #eee; }
-    .categories { display: flex; flex-wrap: wrap; margin: 1rem; }
-    .category { flex: 1 0 300px; background: white; margin: 0.5rem; padding: 1rem; border: 1px solid #ddd; border-radius: 4px; }
-    .category h3 { margin-top: 0; }
-
-    @keyframes gradientShift {
-      0% { background-position: 0% 50%; }
-      50% { background-position: 100% 50%; }
-      100% { background-position: 0% 50%; }
-    }
+    .categories{display:flex;flex-wrap:wrap;margin:1rem;}
+    .category{flex:1 0 250px;background:white;margin:0.5rem;padding:1rem;border:1px solid #ddd;border-radius:4px;}
+    .category h3{margin-top:0;}
   </style>
 </head>
 <body>
-  <header>
+  <header class="hero">
     <h1>FreeGames4Eva — play, rate, create.</h1>
   </header>
-  <div class="hero">
-    <p>Browse 20 000+ free HTML5 games. Every title is graded by the community on Look & Feel, Playability, Creativity and Overall.</p>
-    <p>Ready? Dive into today’s Hot 10 ↓</p>
-  </div>
+  <nav>
+    <ul class="game-links">
+      <li><a href="index.html">Times-Table Quest</a></li>
+      <li><a href="isometric.html">Baby Maze Hunt</a></li>
+      <li><a href="maze.html">Escape School Obby</a></li>
+      <li><a href="torchtd.html">Torch TD</a></li>
+    </ul>
+  </nav>
+  <section class="hero">
+    <p>Browse 20 000+ free HTML5 games. Every title is graded by the community on Look &amp; Feel, Playability, Creativity and Overall.</p>
+  </section>
   <section id="categories" class="categories">
     <div class="category">
       <h3>Maze</h3>
       <p>Time-boxed labyrinths; collect keys, beat the clock.</p>
-      <ul>
-        <li><a href="index.html">Baby Maze Hunt</a> – live</li>
-      </ul>
+      <ul><li><a href="isometric.html">Baby Maze Hunt</a></li></ul>
     </div>
     <div class="category">
       <h3>Obby / Obstacle</h3>
       <p>3-D parkour courses à la Roblox; precision jumps matter.</p>
-      <ul>
-        <li><a href="maze.html">Escape School Obby</a> – new</li>
-      </ul>
-    </div>
-    <div class="category">
-      <h3>Sports</h3>
-      <p>Football, hoops, cricket nets; physics-accurate mini-matches.</p>
-    </div>
-    <div class="category">
-      <h3>Racing</h3>
-      <p>Street, kart, drag & endless-runner variants.</p>
-    </div>
-    <div class="category">
-      <h3>Puzzle</h3>
-      <p>Match-3, sokoban, sliding tiles for the brainiacs.</p>
-    </div>
-    <div class="category">
-      <h3>Strategy</h3>
-      <p>Real-time or turn-based; build, conquer, repeat.</p>
-    </div>
-    <div class="category">
-      <h3>Simulation</h3>
-      <p>Farming, city-builder and life-sim sandboxes.</p>
-    </div>
-    <div class="category">
-      <h3>RPG</h3>
-      <p>Quest-driven stories, XP grind, loot drops.</p>
-    </div>
-    <div class="category">
-      <h3>Adventure</h3>
-      <p>Narrative exploration with light combat/puzzles.</p>
-    </div>
-    <div class="category">
-      <h3>Platformer</h3>
-      <p>Side-scroll classics; double-jump nirvana.</p>
-    </div>
-    <div class="category">
-      <h3>Shooter</h3>
-      <p>First/third-person blasters; aim-assist for mobile.</p>
-    </div>
-    <div class="category">
-      <h3>Tower Defense</h3>
-      <p>Wave after wave; upgrade paths galore.</p>
-    </div>
-    <div class="category">
-      <h3>Arcade / Casual</h3>
-      <p>One-tap mechanics; snack-size fun.</p>
-    </div>
-    <div class="category">
-      <h3>Multiplayer</h3>
-      <p>Real-time lobbies; battle-royale or co-op.</p>
-    </div>
-    <div class="category">
-      <h3>Rhythm / Music</h3>
-      <p>Beat-matching, reaction-time heaven.</p>
-    </div>
-    <div class="category">
-      <h3>Card & Board</h3>
-      <p>Solitaire, chess, deck-builders.</p>
+      <ul><li><a href="maze.html">Escape School Obby</a></li></ul>
     </div>
     <div class="category">
       <h3>Educational</h3>
       <p>Math, coding, geography quizzes.</p>
+      <ul><li><a href="index.html">Times-Table Quest</a></li></ul>
     </div>
     <div class="category">
       <h3>Horror</h3>
       <p>Jumpscares, survival, eerie ambience.</p>
-      <ul>
-        <li><a href="torchtd.html">TorchTD</a> – new</li>
-      </ul>
-    </div>
-    <div class="category">
-      <h3>Sandbox / Creative</h3>
-      <p>Open-ended building, voxel worlds.</p>
-    </div>
-    <div class="category">
-      <h3>VR / AR Ready</h3>
-      <p>WebXR titles for headset owners.</p>
+      <ul><li><a href="torchtd.html">Torch TD</a></li></ul>
     </div>
   </section>
 </body>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <a href="baseline.html" class="back-link">← Games</a>
   <header class="hero" role="banner">
     <h1>Times-Table Quest</h1>
     <button id="contrastToggle" aria-label="Toggle high contrast" role="switch">HC</button>

--- a/isometric.html
+++ b/isometric.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Baby Maze Hunt</title>
+  <link rel="stylesheet" href="style.css">
   <style>
     html, body {
       margin: 0;
@@ -65,6 +66,7 @@
   </style>
 </head>
 <body>
+  <a href="baseline.html" class="back-link">← Games</a>
   <div id="gameBoard"></div>
   <div id="gameOver">😭 Baby is crying! Game Over!</div>
   <div id="success" style="display:none; position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); background:rgba(0,0,0,0.7); color:#fff; padding:2rem; font-size:2rem;">You Succeeded!</div>

--- a/maze.html
+++ b/maze.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Escape School Obby</title>
+  <link rel="stylesheet" href="style.css">
   <style>
     html,body{
       margin:0;
@@ -16,7 +17,9 @@
       align-items:center;
       font-family:'Segoe UI', Arial, sans-serif;
     }
-    canvas{
+    .iso-container{perspective:800px;}
+  .iso-container canvas{transform:rotateX(60deg) rotateZ(45deg);transform-style:preserve-3d;}
+  canvas{
       background:linear-gradient(#fff,#eee);
       border:2px solid #333;
       box-shadow:0 20px 30px rgba(0,0,0,0.3);
@@ -46,9 +49,12 @@
   </style>
 </head>
 <body>
+  <a href="baseline.html" class="back-link">← Games</a>
+  <div class="iso-container">
   <canvas id="gameCanvas" width="600" height="600"></canvas>
   <div id="gameOver">You got caught! Game Over!</div>
   <button id="restart">Start Obby</button>
+</div>
 <script>
 const canvas=document.getElementById('gameCanvas');
 const ctx=canvas.getContext('2d');

--- a/style.css
+++ b/style.css
@@ -172,3 +172,35 @@ button:focus {
   height: 100%;
   pointer-events: none;
 }
+.game-links{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:center;
+  gap:0.5rem;
+}
+.game-links a{
+  text-decoration:none;
+  color:inherit;
+  padding:0.25rem 0.5rem;
+}
+.back-link{
+  position:absolute;
+  top:0.5rem;
+  left:0.5rem;
+  text-decoration:none;
+  color:#fff;
+  background:rgba(0,0,0,0.5);
+  padding:0.25rem 0.5rem;
+  border-radius:4px;
+  z-index:1000;
+}
+.iso-container{
+  perspective:800px;
+}
+.iso-container canvas{
+  transform:rotateX(60deg) rotateZ(45deg);
+  transform-style:preserve-3d;
+}

--- a/torchtd.html
+++ b/torchtd.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TorchTD</title>
+  <link rel="stylesheet" href="style.css">
   <style>
     html,body{
       margin:0;
@@ -16,7 +17,9 @@
       align-items:center;
       font-family:'Segoe UI', Arial, sans-serif;
     }
-    canvas{
+    .iso-container{perspective:800px;}
+  .iso-container canvas{transform:rotateX(60deg) rotateZ(45deg);transform-style:preserve-3d;}
+  canvas{
       background:linear-gradient(#333,#111);
       border:2px solid #444;
       box-shadow:0 20px 30px rgba(0,0,0,0.4);
@@ -48,12 +51,15 @@
   </style>
 </head>
 <body>
+  <a href="baseline.html" class="back-link">← Games</a>
+  <div class="iso-container">
   <canvas id="gameCanvas" width="600" height="600"></canvas>
   <div id="gameOver">😱 The monsters got you! Game Over!</div>
   <div id="success" style="display:none; position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); background:rgba(0,0,0,0.7); color:#fff; padding:2rem; font-size:2rem;">Stage Clear!</div>
   <button id="restart">Start Game</button>
   <button id="nextStage" style="display:none; position:absolute; top:60%; left:50%; transform:translate(-50%,-50%); padding:0.5rem 1rem; font-size:1.2rem; cursor:pointer; background:#2196f3; color:white; border:none; border-radius:4px;">Start Stage 2</button>
   <button id="nextStage3" style="display:none; position:absolute; top:65%; left:50%; transform:translate(-50%,-50%); padding:0.5rem 1rem; font-size:1.2rem; cursor:pointer; background:#ff5722; color:white; border:none; border-radius:4px;">Start Stage 3</button>
+</div>
   <script>
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas.getContext('2d');

--- a/ttq-single.html
+++ b/ttq-single.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Times-Table Quest (Standalone)</title>
+  <link rel="stylesheet" href="style.css">
   <style>
 :root {
   --primary: #4e63ff;
@@ -186,6 +187,7 @@ body.high-contrast #hud{background:#000;color:#fff;}
   </style>
 </head>
 <body>
+  <a href="baseline.html" class="back-link">← Games</a>
   <header class="hero" role="banner">
     <h1>Times-Table Quest</h1>
     <button id="contrastToggle" aria-label="Toggle high contrast" role="switch">HC</button>


### PR DESCRIPTION
## Summary
- update `baseline.html` to act as a hub with links to each game
- add back links on all game pages
- add reusable CSS for navigation and simple isometric transforms
- wrap maze and Torch TD canvases in an isometric container

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857aa0f35dc8321bdf28f67013d5a9a