### PR TITLE
Add isometric projection to maze

### DIFF
--- a/maze.html
+++ b/maze.html
@@ -73,16 +73,21 @@ const GRID=[
   [1,0,0,0,0,1,0,0,0,1],
   [1,1,1,1,1,1,1,1,1,1]
 ];
-let TILE;
+let TILE, TILE_W, TILE_H, OFFSET_X, OFFSET_Y;
 const PLAYER_EMOJI='🏃';
 const TEACHER_EMOJI='👩\u200d🏫';
 const BOOK_EMOJI='📚';
 let player,item,teachers,gameOver,score,timeStart,timerId;
 
 function resize(){
-  const size=Math.min(window.innerWidth,window.innerHeight);
-  canvas.width=size;canvas.height=size;
-  TILE=canvas.width/GRID.length;
+  const size = Math.min(window.innerWidth, window.innerHeight);
+  canvas.width = size;
+  canvas.height = size;
+  TILE = canvas.width / GRID.length;
+  TILE_W = TILE;
+  TILE_H = TILE;
+  OFFSET_X = (GRID.length - 1) * TILE_W / 2;
+  OFFSET_Y = TILE_H;
 }
 window.addEventListener('resize',resize);
 
@@ -127,6 +132,13 @@ function isWall(x,y){
   return GRID[gy]&&GRID[gy][gx]===1;
 }
 
+function toIso(gx, gy){
+  return {
+    x: (gx - gy) * TILE_W / 2 + OFFSET_X,
+    y: (gx + gy) * TILE_H / 4
+  };
+}
+
 canvas.addEventListener('click',e=>{
   if(gameOver)return;
   const rect=canvas.getBoundingClientRect();
@@ -164,28 +176,64 @@ function update(){
 
 function draw(){
   ctx.clearRect(0,0,canvas.width,canvas.height);
-  const t=Date.now()/200;
-  for(let y=0;y<GRID.length;y++){
-    for(let x=0;x<GRID[y].length;x++){
-      if(GRID[y][x]===1){
-        const b=Math.sin(t+x+y)*4;
-        ctx.font=`${TILE*0.8}px sans-serif`;
-        ctx.textAlign='center';ctx.textBaseline='middle';
-        ctx.fillText('🪑',x*TILE+TILE/2,y*TILE+TILE/2-b);
-      }else{
-        ctx.fillStyle='#ddd';
-        ctx.fillRect(x*TILE,y*TILE,TILE,TILE);
-      }
+  const t = Date.now() / 200;
+
+  // draw tiles
+  for(let y=0; y<GRID.length; y++){
+    for(let x=0; x<GRID[y].length; x++){
+      const iso = toIso(x, y);
+      ctx.beginPath();
+      ctx.moveTo(iso.x, iso.y + OFFSET_Y);
+      ctx.lineTo(iso.x + TILE_W/2, iso.y + TILE_H/4 + OFFSET_Y);
+      ctx.lineTo(iso.x, iso.y + TILE_H/2 + OFFSET_Y);
+      ctx.lineTo(iso.x - TILE_W/2, iso.y + TILE_H/4 + OFFSET_Y);
+      ctx.closePath();
+      ctx.fillStyle = GRID[y][x] === 1 ? '#2e7d32' : '#ddd';
+      ctx.fill();
     }
   }
-  const bItem=Math.sin(t+item.x+item.y)*4;
-  ctx.font=`${item.r*2}px sans-serif`;ctx.textAlign='center';ctx.textBaseline='middle';ctx.fillText(BOOK_EMOJI,item.x,item.y-bItem);
-  const bPlayer=Math.sin(t+player.x+player.y)*4;
-  ctx.font=`${player.r*2}px sans-serif`;ctx.fillText(PLAYER_EMOJI,player.x,player.y-bPlayer);
-  for(const t of teachers){ const bT=Math.sin(t+t.x+t.y)*4; ctx.font=`${t.r*2}px sans-serif`; ctx.fillText(TEACHER_EMOJI,t.x,t.y-bT);} 
-  ctx.fillStyle='rgba(255,255,255,0.8)';ctx.fillRect(5,5,130,50);ctx.fillStyle='#000';ctx.font='bold 20px Arial';
-  const timeLeft=Math.max(0,15-Math.floor((Date.now()-timeStart)/1000));
-  ctx.fillText(`Time:${timeLeft}s`,10,30); ctx.fillText(`Score:${score}`,10,50);
+
+  // depth sorted entities
+  const entities = [];
+  const itemIso = toIso(item.x / TILE, item.y / TILE);
+  const bounceItem = Math.sin(t + item.x + item.y) * 4;
+  entities.push({y: itemIso.y, draw: () => {
+    ctx.font = `${item.r*2}px sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(BOOK_EMOJI, itemIso.x, itemIso.y - TILE_H/2 + bounceItem + OFFSET_Y);
+  }});
+
+  const playerIso = toIso(player.x / TILE, player.y / TILE);
+  const bouncePlayer = Math.sin(t + player.x + player.y) * 4;
+  entities.push({y: playerIso.y, draw: () => {
+    ctx.font = `${player.r*2}px sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(PLAYER_EMOJI, playerIso.x, playerIso.y - TILE_H/2 + bouncePlayer + OFFSET_Y);
+  }});
+
+  for(const te of teachers){
+    const teIso = toIso(te.x / TILE, te.y / TILE);
+    const bT = Math.sin(t + te.x + te.y) * 4;
+    entities.push({y: teIso.y, draw: () => {
+      ctx.font = `${te.r*2}px sans-serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(TEACHER_EMOJI, teIso.x, teIso.y - TILE_H/2 + bT + OFFSET_Y);
+    }});
+  }
+
+  entities.sort((a,b) => a.y - b.y);
+  for(const e of entities){ e.draw(); }
+
+  ctx.fillStyle = 'rgba(255,255,255,0.8)';
+  ctx.fillRect(5,5,130,50);
+  ctx.fillStyle = '#000';
+  ctx.font = 'bold 20px Arial';
+  const timeLeft = Math.max(0,15-Math.floor((Date.now()-timeStart)/1000));
+  ctx.fillText(`Time:${timeLeft}s`,10,30);
+  ctx.fillText(`Score:${score}`,10,50);
 }
 
 function loop(){update();draw(); if(!gameOver) requestAnimationFrame(loop);}


### PR DESCRIPTION
## Summary
- switch maze game drawing to an isometric projection
- depth sort entities by Y coordinate for correct layering

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6857b46dea3483219c399cc136398daa